### PR TITLE
Use a map to make blacklisting faster

### DIFF
--- a/blacklist.go
+++ b/blacklist.go
@@ -13,7 +13,7 @@ import (
 
 const blacklistPath = "blacklist"
 
-var blacklist []string
+var blacklist = make(map[string]bool)
 
 func loadBlacklistedKeys() {
 	files, err := ioutil.ReadDir(blacklistPath)
@@ -34,7 +34,8 @@ func loadBlacklistedKeys() {
 
 		scanner := bufio.NewScanner(file)
 		for scanner.Scan() {
-			blacklist = append(blacklist, scanner.Text())
+			key := strings.TrimSpace(scanner.Text())
+			blacklist[key] = true
 		}
 
 		if err := scanner.Err(); err != nil {
@@ -46,11 +47,11 @@ func loadBlacklistedKeys() {
 }
 
 func markBlacklistedKeys(keys []*publicKey) {
-	for _, b := range blacklist {
-		for _, k := range keys {
-			if strings.TrimSpace(b) == strings.TrimSpace(string(ssh.MarshalAuthorizedKey(k.key))) {
-				k.blacklisted = true
-			}
+
+	for _, k := range keys {
+		key := strings.TrimSpace(string(ssh.MarshalAuthorizedKey(k.key)))
+		if blacklist[key] {
+			k.blacklisted = true
 		}
 	}
 


### PR DESCRIPTION
The operation to iteratively search through the blacklisted keys and
compare each one to the public keys presented by the user is noticeably
slow.

Make it faster by using a map of booleans indexed by the blacklisted key
as a string. If a given key is not in the blacklist, `blacklist[key]`
will evaluate to false.

This should be an O(1) operation rather than a O(n) operation as it was
previously.
